### PR TITLE
Fix broken navigation links in development page

### DIFF
--- a/development/index.html
+++ b/development/index.html
@@ -97,11 +97,11 @@
 
 <footer class="footer" align="center">
   <div class="width text-center">
-    <a href="docs/current/">Documentation</a>&ensp;·&ensp;
-    <a href="community.html">Community</a>&ensp;·&ensp;
-    <a href="resources.html">Resources</a>&ensp;·&ensp;
-    <a href="development">Development</a>&ensp;·&ensp;
-    <a href="download.html">Download</a>
+    <a href="/docs/current/">Documentation</a>&ensp;·&ensp;
+    <a href="/community.html">Community</a>&ensp;·&ensp;
+    <a href="/resources.html">Resources</a>&ensp;·&ensp;
+    <a href="/development">Development</a>&ensp;·&ensp;
+    <a href="/download.html">Download</a>
   </div>
   <div class="width text-center">
     <p class="text-center">


### PR DESCRIPTION
They are relative links so they resolve to `prestosql.io/development/docs`, etc.